### PR TITLE
fix(cb2-8130): open api copy contents of generated folder

### DIFF
--- a/.github/workflows/openapi-gen.yml
+++ b/.github/workflows/openapi-gen.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           rm -rf pr_repo/${{inputs.pr_repository_path}}
           mkdir -p pr_repo/${{inputs.pr_repository_path}}
-          cp -r generated pr_repo/${{inputs.pr_repository_path}}
+          cp -r generated/. pr_repo/${{inputs.pr_repository_path}}
 
       - name: Check for changes
         id: change-check


### PR DESCRIPTION
## Ticket title

Copy the contents of the generated folder as opposed to the folder itself

[CB2-8130](https://dvsa.atlassian.net/browse/CB2-8130)

## Checklist
- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number