### PR TITLE
Add sentry deploy step for prod builds

### DIFF
--- a/.github/workflows/build-mobile.yaml
+++ b/.github/workflows/build-mobile.yaml
@@ -7,7 +7,7 @@ on:
         required: true
       branch:
         type: string
-        required: true      
+        required: true
       cert_repo_branch:
         type: string
         required: true
@@ -20,7 +20,7 @@ on:
       env_file:
         type: string
         required: true
-    
+
     secrets:
       IONIC_HUB_PRODUCT_KEY:
         required: true
@@ -52,12 +52,12 @@ jobs:
 
     steps:
       - name: ⚙️ Get Codebase
-        uses: actions/checkout@v3
-        with: 
+        uses: actions/checkout@v4
+        with:
           ref: ${{ inputs.branch }}
 
       - name: ⚙️ Configure Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
 
@@ -68,7 +68,7 @@ jobs:
           branch=$(python3 -c "print('$clean'.lower())")
           echo "BRANCH=$(echo $branch)" >> $GITHUB_OUTPUT
         id: branch
-      
+
       - name: ⚙️ Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -96,6 +96,10 @@ jobs:
 
       - name: 🛠️ Build Project
         run: npm run build-ci
+
+      - name: ☁️️ Deploy Sentry
+        if: ${{ inputs.environment == 'prod' }}
+        run: npm run sentry-deploy
 
       - name: 📱 Run Fastlane
         env:


### PR DESCRIPTION
## Ticket title
- Move sentry deploy into own step which should run only against production (`'prod'`) builds

## Checklist
- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number