### PR TITLE
Build Services from hash adding local mysql and liquibase compatibility

### DIFF
--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -41,54 +41,28 @@ jobs:
         env:
           DB_PASSWORD: 12345
         run: |
-          sudo echo "mysql-server mysql-server/root_password_again password $DB_PASSWORD" | debconf-set-selections
           sudo systemctl start mysql.service
+          mysqladmin -u root -p root password ${DB_PASSWORD}
 
       - name: Install Liquibase
         env:
           LB_VERSION: 4.23.0
-          MJC_VERSION: 8.0.25
-#        run: |
-#          wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
-#          cat liquibase-keyring.gpg | sudo tee /usr/share/keyrings/liquibase-keyring.gpg > /dev/null && \
-#          echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/liquibase-keyring.gpg] https://repo.liquibase.com stable main' | sudo tee /etc/apt/sources.list.d/liquibase.list
-#          sudo apt-get update && sudo apt-get install liquibase=${LB_VERSION}
-#          whereis liquibase
+          MCJ_VERSION: 8.0.25
         run: |
           curl -L https://github.com/liquibase/liquibase/releases/download/v${LB_VERSION}/liquibase-${LB_VERSION}.zip --output liquibase-${LB_VERSION}.zip
           unzip -o -d liquibase liquibase-${LB_VERSION}.zip
           echo "$GITHUB_WORKSPACE/liquibase" >> $GITHUB_PATH
           sudo mkdir -p /liquibase/lib/
-          sudo curl -L https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MJC_VERSION}/mysql-connector-java-${MJC_VERSION}.jar --output /liquibase/lib/mysql.jar
+          sudo curl -L https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MCJ_VERSION}/mysql-connector-java-${MCJ_VERSION}.jar --output /liquibase/lib/mysql.jar
 
-#  echo "mysql-server mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD" | debconf-set-selections
-
-## Make /liquibase directory and change owner to liquibase
-#  RUN mkdir /liquibase
-#  WORKDIR /liquibase
-#
-#  #Symbolic link will be broken until later
-#  RUN ln -s /liquibase/liquibase /usr/local/bin/liquibase
-#
-#  # Latest Liquibase Release Version
-#  ARG LIQUIBASE_VERSION=4.23.0
-#
-#  # Download, verify, extract
-#  ARG LB_SHA256=988b8734da3f2f987646fa533748d9b7aae2f889741fd6922f86ae3a321ea635
-#  RUN set -x \
-#  && wget -q -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://github.com/liquibase/liquibase/releases/download/v${LIQUIBASE_VERSION}/liquibase-${LIQUIBASE_VERSION}.tar.gz" \
-#  && echo "$LB_SHA256  liquibase-${LIQUIBASE_VERSION}.tar.gz" | sha256sum -c - \
-#  && tar -xzf liquibase-${LIQUIBASE_VERSION}.tar.gz \
-#  && rm liquibase-${LIQUIBASE_VERSION}.tar.gz
-#
-#  ARG MYSQL_SHA256=a0a1be0389e541dad8841b326e79c51d39abbe1ca52267304d76d1cf4801ce96
-#  RUN wget --no-verbose -O /liquibase/lib/mysql.jar https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.25/mysql-connector-java-8.0.25.jar \
-#  && wget --no-verbose -O /liquibase/lib/mysql.jar.asc https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.25/mysql-connector-java-8.0.25.jar.asc \
-#  && gpg --auto-key-locate keyserver --keyserver keyserver.ubuntu.com --keyserver-options auto-key-retrieve --verify /liquibase/lib/mysql.jar.asc /liquibase/lib/mysql.jar \
-#  && echo "$MYSQL_SHA256  /liquibase/lib/mysql.jar" | sha256sum -c -
+      - name: Checkout CVS-NOP
+        uses: actions/checkout@v4
+        with:
+          repository: dvsa/cvs-nop
 
       - name: Install tools
         run: npm run tools-setup
+#    "tools-setup": "liquibase --changeLogFile ../cvs-nop/changelog-master.xml --username root --password 12345 --url jdbc:mysql://127.0.0.1:3306/CVSBNOP?createDatabaseIfNotExist=true --classpath /liquibase/lib/mysql.jar update"
 
       - name: Build Artifact
         run: npm run build

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -60,6 +60,11 @@ jobs:
           path: cvs-nop
           ref: ${{ github.ref }}
 
+      - name: List Dirs
+        run: |
+          ls -al
+          ls -al ..
+
       - name: Install tools
         run: npm run tools-setup
 #    "tools-setup": "liquibase --changeLogFile ../cvs-nop/changelog-master.xml --username root --password 12345 --url jdbc:mysql://127.0.0.1:3306/CVSBNOP?createDatabaseIfNotExist=true --classpath /liquibase/lib/mysql.jar update"

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -48,6 +48,7 @@ jobs:
           cat liquibase-keyring.gpg | sudo tee /usr/share/keyrings/liquibase-keyring.gpg > /dev/null && \
           echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/liquibase-keyring.gpg] https://repo.liquibase.com stable main' | sudo tee /etc/apt/sources.list.d/liquibase.list
           sudo apt-get update && sudo apt-get install liquibase=${LB_VERSION}
+          whereis liquibase
 #        run: |
 #          curl -L https://github.com/liquibase/liquibase/releases/download/v${LB_VERSION}/liquibase-${LB_VERSION}.zip --output liquibase-${LB_VERSION}.zip
 #          unzip -o -d liquibase liquibase-${LB_VERSION}.zip

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -43,22 +43,16 @@ jobs:
       - name: Install Liquibase
         env:
           LB_VERSION: 4.23.0
-        run: |
-          wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
-          cat liquibase-keyring.gpg | sudo tee /usr/share/keyrings/liquibase-keyring.gpg > /dev/null && \
-          echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/liquibase-keyring.gpg] https://repo.liquibase.com stable main' | sudo tee /etc/apt/sources.list.d/liquibase.list
-          sudo apt-get update && sudo apt-get install liquibase=${LB_VERSION}
-          whereis liquibase
 #        run: |
-#          curl -L https://github.com/liquibase/liquibase/releases/download/v${LB_VERSION}/liquibase-${LB_VERSION}.zip --output liquibase-${LB_VERSION}.zip
-#          unzip -o -d liquibase liquibase-${LB_VERSION}.zip
-#          echo "GITHUB_PATH: $GITHUB_PATH"
-#          echo "HOME: $HOME"
-#          echo "GITHUB_WORKSPACE: $GITHUB_WORKSPACE"
-#          pwd
-#          ls -al
-#          echo "$HOME/liquibase" >> $GITHUB_PATH
-#          ./liquibase/liquibase --version
+#          wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
+#          cat liquibase-keyring.gpg | sudo tee /usr/share/keyrings/liquibase-keyring.gpg > /dev/null && \
+#          echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/liquibase-keyring.gpg] https://repo.liquibase.com stable main' | sudo tee /etc/apt/sources.list.d/liquibase.list
+#          sudo apt-get update && sudo apt-get install liquibase=${LB_VERSION}
+#          whereis liquibase
+        run: |
+          curl -L https://github.com/liquibase/liquibase/releases/download/v${LB_VERSION}/liquibase-${LB_VERSION}.zip --output liquibase-${LB_VERSION}.zip
+          unzip -o -d liquibase liquibase-${LB_VERSION}.zip
+          echo "$GITHUB_WORKSPACE/liquibase" >> $GITHUB_PATH
           
 ## Make /liquibase directory and change owner to liquibase
 #  RUN mkdir /liquibase

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -55,7 +55,7 @@ jobs:
           unzip -o -d liquibase liquibase-${LB_VERSION}.zip
           echo "$GITHUB_WORKSPACE/liquibase" >> $GITHUB_PATH
           sudo mkdir -p /liquibase/lib/
-          curl -L https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MJC_VERSION}/mysql-connector-java-${MJC_VERSION}.jar --output /liquibase/lib/mysql.jar
+          sudo curl -L https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MJC_VERSION}/mysql-connector-java-${MJC_VERSION}.jar --output /liquibase/lib/mysql.jar
           
 ## Make /liquibase directory and change owner to liquibase
 #  RUN mkdir /liquibase

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -21,13 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          path: main
-
-      - name: List Dirs
-        run: |
-          ls -al
-          ls -al ..
 
       - name: Get AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -66,11 +59,7 @@ jobs:
           repository: dvsa/cvs-nop
           path: cvs-nop
           ref: ${{ github.ref }}
-
-      - name: List Dirs
-        run: |
-          ls -al
-          ls -al ..
+      - run: mv cvs-nop/ ..
 
       - name: Install tools
         run: npm run tools-setup

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: dvsa/cvs-nop
-          path: ../cvs-nop
+          path: $GITHUB_WORKSPACE/cvs-nop
           ref: ${{ github.ref }}
 
       - name: List Dirs

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -39,6 +39,7 @@ jobs:
 
       - name: Start MySQL
         run: |
+          cat /etc/hosts
           sudo systemctl start mysql.service
           mysqladmin -u root -p'root' password 12345
 

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -48,6 +48,7 @@ jobs:
           unzip -o -d liquibase liquibase-${LB_VERSION}.zip
           echo "GITHUB_PATH: $GITHUB_PATH"
           echo "HOME: $HOME"
+          echo "GITHUB_WORKSPACE: $GITHUB_WORKSPACE"
           pwd
           ls -al
           echo "$HOME/liquibase" >> $GITHUB_PATH

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -54,7 +54,7 @@ jobs:
           curl -L https://github.com/liquibase/liquibase/releases/download/v${LB_VERSION}/liquibase-${LB_VERSION}.zip --output liquibase-${LB_VERSION}.zip
           unzip -o -d liquibase liquibase-${LB_VERSION}.zip
           echo "$GITHUB_WORKSPACE/liquibase" >> $GITHUB_PATH
-          curl -L https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MJC_VERSION}/mysql-connector-java-${MJC_VERSION}.jar --output /liquibase/lib/mysql.jar
+          curl -L https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MJC_VERSION}/mysql-connector-java-${MJC_VERSION}.jar --create-dirs --output /liquibase/lib/mysql.jar
           
 ## Make /liquibase directory and change owner to liquibase
 #  RUN mkdir /liquibase

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -43,16 +43,17 @@ jobs:
       - name: Install Liquibase
         env:
           LB_VERSION: 4.23.0
-        run: |
-          curl -L https://github.com/liquibase/liquibase/releases/download/v${LB_VERSION}/liquibase-${LB_VERSION}.zip --output liquibase-${LB_VERSION}.zip
-          unzip -o -d liquibase liquibase-${LB_VERSION}.zip
-          echo "GITHUB_PATH: $GITHUB_PATH"
-          echo "HOME: $HOME"
-          echo "GITHUB_WORKSPACE: $GITHUB_WORKSPACE"
-          pwd
-          ls -al
-          echo "$HOME/liquibase" >> $GITHUB_PATH
-          ./liquibase/liquibase --version
+        run: sudo apt-get install liquibase=${LB_VERSION}
+#        run: |
+#          curl -L https://github.com/liquibase/liquibase/releases/download/v${LB_VERSION}/liquibase-${LB_VERSION}.zip --output liquibase-${LB_VERSION}.zip
+#          unzip -o -d liquibase liquibase-${LB_VERSION}.zip
+#          echo "GITHUB_PATH: $GITHUB_PATH"
+#          echo "HOME: $HOME"
+#          echo "GITHUB_WORKSPACE: $GITHUB_WORKSPACE"
+#          pwd
+#          ls -al
+#          echo "$HOME/liquibase" >> $GITHUB_PATH
+#          ./liquibase/liquibase --version
           
 ## Make /liquibase directory and change owner to liquibase
 #  RUN mkdir /liquibase

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Start MySQL
         if: ${{ inputs.mysql_liquibase == true }}
         run: |
-          sudo /usr/local/mysql/support-files/mysql.server start
+          ls /usr/local/mysql
           mysqladmin -u root -p'root' password 12345
 
       - name: Install Liquibase

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -49,10 +49,8 @@ jobs:
       - name: Start MySQL
         if: ${{ inputs.mysql_liquibase == true }}
         run: |
-          sudo systemctl start mysql.service
+          sudo /usr/local/mysql/support-files/mysql.server start
           mysqladmin -u root -p'root' password 12345
-          # remove ipv6 localhost to allow test-i pack to run correctly
-          sudo sed -i '/::1     localhost/d' /etc/hosts
 
       - name: Install Liquibase
         if: ${{ inputs.mysql_liquibase == true }}

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -39,7 +39,6 @@ jobs:
 
       - name: Start MySQL
         run: |
-          cat /etc/hosts
           sudo systemctl start mysql.service
           mysqladmin -u root -p'root' password 12345
 
@@ -65,6 +64,9 @@ jobs:
       - name: Install tools
         run: npm run tools-setup
 #    "tools-setup": "liquibase --changeLogFile ../cvs-nop/changelog-master.xml --username root --password 12345 --url jdbc:mysql://127.0.0.1:3306/CVSBNOP?createDatabaseIfNotExist=true --classpath /liquibase/lib/mysql.jar update"
+
+      - name: Test DB access
+        run: mysql -u root -p'12345' -h localhost -P 3306 -D CVSNOP
 
       - name: Build Artifact
         run: npm run build

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, X64]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -46,6 +46,8 @@ jobs:
         run: |
           curl -L https://github.com/liquibase/liquibase/releases/download/v${LB_VERSION}/liquibase-${LB_VERSION}.zip --output liquibase-${LB_VERSION}.zip
           unzip -o -d liquibase liquibase-${LB_VERSION}.zip
+          echo "GITHUB_PATH: $GITHUB_PATH"
+          echo "HOME: $HOME"
           pwd
           ls -al
           echo "$HOME/liquibase" >> $GITHUB_PATH

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: ${{ github.event.repository.name }}
 
       - name: Get AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -57,7 +59,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: dvsa/cvs-nop
-          path: $GITHUB_WORKSPACE/cvs-nop
+          path: cvs-nop
           ref: ${{ github.ref }}
 
       - name: List Dirs

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -38,11 +38,9 @@ jobs:
         run: npm ci
 
       - name: Start MySQL
-        env:
-          DB_PASSWORD: 12345
         run: |
           sudo systemctl start mysql.service
-          mysqladmin -u root -p root password ${DB_PASSWORD}
+          mysqladmin -u root -p'root' password 12345
 
       - name: Install Liquibase
         env:

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -41,7 +41,8 @@ jobs:
         run: |
           sudo systemctl start mysql.service
           mysqladmin -u root -p'root' password 12345
-          sudo echo "::1 localhost" | sudo tee -a /etc/hosts
+          cat /etc/hosts
+          sudo sed -i '/::1/d' /etc/hosts
           cat /etc/hosts
 
       - name: Install Liquibase

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Liquibase
         env:
           LB_VERSION: 4.23.0
-        run: sudo apt-get install liquibase=${LB_VERSION}
+        run: sudo apt-get update && sudo apt-get install liquibase=${LB_VERSION}
 #        run: |
 #          curl -L https://github.com/liquibase/liquibase/releases/download/v${LB_VERSION}/liquibase-${LB_VERSION}.zip --output liquibase-${LB_VERSION}.zip
 #          unzip -o -d liquibase liquibase-${LB_VERSION}.zip

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -43,6 +43,7 @@ jobs:
       - name: Install Liquibase
         env:
           LB_VERSION: 4.23.0
+          MJC_VERSION: 8.0.25
 #        run: |
 #          wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
 #          cat liquibase-keyring.gpg | sudo tee /usr/share/keyrings/liquibase-keyring.gpg > /dev/null && \
@@ -53,6 +54,7 @@ jobs:
           curl -L https://github.com/liquibase/liquibase/releases/download/v${LB_VERSION}/liquibase-${LB_VERSION}.zip --output liquibase-${LB_VERSION}.zip
           unzip -o -d liquibase liquibase-${LB_VERSION}.zip
           echo "$GITHUB_WORKSPACE/liquibase" >> $GITHUB_PATH
+          curl -L https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MJC_VERSION}/mysql-connector-java-${MJC_VERSION}.jar --output /liquibase/lib/mysql.jar
           
 ## Make /liquibase directory and change owner to liquibase
 #  RUN mkdir /liquibase

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -41,8 +41,9 @@ jobs:
         env:
           DB_PASSWORD: 12345
         run: |
+          printenv
           sudo systemctl start mysql.service
-          mysqladmin -u root password ${DB_PASSWORD}
+          mysqladmin -u root -p'root' password ${DB_PASSWORD}
 
       - name: Install Liquibase
         env:

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -43,7 +43,11 @@ jobs:
       - name: Install Liquibase
         env:
           LB_VERSION: 4.23.0
-        run: sudo apt-get update && sudo apt-get install liquibase=${LB_VERSION}
+        run: |
+          wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
+          cat liquibase-keyring.gpg | sudo tee /usr/share/keyrings/liquibase-keyring.gpg > /dev/null && \
+          echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/liquibase-keyring.gpg] https://repo.liquibase.com stable main' | sudo tee /etc/apt/sources.list.d/liquibase.list
+          sudo apt-get update && sudo apt-get install liquibase=${LB_VERSION}
 #        run: |
 #          curl -L https://github.com/liquibase/liquibase/releases/download/v${LB_VERSION}/liquibase-${LB_VERSION}.zip --output liquibase-${LB_VERSION}.zip
 #          unzip -o -d liquibase liquibase-${LB_VERSION}.zip

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -54,7 +54,7 @@ jobs:
           curl -L https://github.com/liquibase/liquibase/releases/download/v${LB_VERSION}/liquibase-${LB_VERSION}.zip --output liquibase-${LB_VERSION}.zip
           unzip -o -d liquibase liquibase-${LB_VERSION}.zip
           echo "$GITHUB_WORKSPACE/liquibase" >> $GITHUB_PATH
-          mkdir -p /liquibase/lib/
+          sudo mkdir -p /liquibase/lib/
           curl -L https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MJC_VERSION}/mysql-connector-java-${MJC_VERSION}.jar --output /liquibase/lib/mysql.jar
           
 ## Make /liquibase directory and change owner to liquibase

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -38,7 +38,11 @@ jobs:
         run: npm ci
 
       - name: Start MySQL
-        run: sudo systemctl start mysql.service
+        env:
+          DB_PASSWORD: 12345
+        run: |
+          sudo systemctl start mysql.service
+          mysqladmin -u root password ${DB_PASSWORD}
 
       - name: Install Liquibase
         env:

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -38,7 +38,11 @@ jobs:
         run: npm ci
 
       - name: Start MySQL
-        run: sudo systemctl start mysql.service
+        run: |
+          sudo systemctl start mysql.service
+          sudo systemctl status mysql.service
+          mysql
+          mysql --version
 
       - name: Install Liquibase
         env:

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -41,6 +41,8 @@ jobs:
         run: |
           sudo systemctl start mysql.service
           mysqladmin -u root -p'root' password 12345
+          sudo echo "::1 localhost" | sudo tee -a /etc/hosts
+          cat /etc/hosts
 
       - name: Install Liquibase
         env:
@@ -66,7 +68,7 @@ jobs:
 #    "tools-setup": "liquibase --changeLogFile ../cvs-nop/changelog-master.xml --username root --password 12345 --url jdbc:mysql://127.0.0.1:3306/CVSBNOP?createDatabaseIfNotExist=true --classpath /liquibase/lib/mysql.jar update"
 
       - name: Test DB access
-        run: mysql -u root -p'12345' -h localhost -P 3306 -D CVSNOP
+        run: mysql -u root -p'12345' -h localhost -P 3306 -D CVSBNOP
 
       - name: Build Artifact
         run: npm run build

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -57,6 +57,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: dvsa/cvs-nop
+          path: cvs-nop
+          ref: ${{ github.ref }}
 
       - name: Install tools
         run: npm run tools-setup

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -38,11 +38,7 @@ jobs:
         run: npm ci
 
       - name: Start MySQL
-        run: |
-          sudo systemctl start mysql.service
-          sudo systemctl status mysql.service
-          mysql
-          mysql --version
+        run: sudo systemctl start mysql.service
 
       - name: Install Liquibase
         env:
@@ -50,6 +46,9 @@ jobs:
         run: |
           curl -L https://github.com/liquibase/liquibase/releases/download/v${LB_VERSION}/liquibase-${LB_VERSION}.zip --output liquibase-${LB_VERSION}.zip
           unzip -o -d liquibase liquibase-${LB_VERSION}.zip
+          pwd
+          ls -al
+          echo "$HOME/liquibase" >> $GITHUB_PATH
           ./liquibase/liquibase --version
           
 ## Make /liquibase directory and change owner to liquibase

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          path: ${{ github.event.repository.name }}
+          path: main
 
       - name: Get AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -37,8 +37,43 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-#      - name: Install tools
-#        run: npm run tools-setup
+      - name: Start MySQL
+        run: sudo systemctl start mysql.service
+
+      - name: Install Liquibase
+        env:
+          LB_VERSION: 4.23.0
+        run: |
+          curl -L https://github.com/liquibase/liquibase/releases/download/v${LB_VERSION}/liquibase-${LB_VERSION}.zip --output liquibase-${LB_VERSION}.zip
+          unzip -o -d liquibase liquibase-${LB_VERSION}.zip
+          ./liquibase/liquibase --version
+          
+## Make /liquibase directory and change owner to liquibase
+#  RUN mkdir /liquibase
+#  WORKDIR /liquibase
+#
+#  #Symbolic link will be broken until later
+#  RUN ln -s /liquibase/liquibase /usr/local/bin/liquibase
+#
+#  # Latest Liquibase Release Version
+#  ARG LIQUIBASE_VERSION=4.23.0
+#
+#  # Download, verify, extract
+#  ARG LB_SHA256=988b8734da3f2f987646fa533748d9b7aae2f889741fd6922f86ae3a321ea635
+#  RUN set -x \
+#  && wget -q -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://github.com/liquibase/liquibase/releases/download/v${LIQUIBASE_VERSION}/liquibase-${LIQUIBASE_VERSION}.tar.gz" \
+#  && echo "$LB_SHA256  liquibase-${LIQUIBASE_VERSION}.tar.gz" | sha256sum -c - \
+#  && tar -xzf liquibase-${LIQUIBASE_VERSION}.tar.gz \
+#  && rm liquibase-${LIQUIBASE_VERSION}.tar.gz
+#
+#  ARG MYSQL_SHA256=a0a1be0389e541dad8841b326e79c51d39abbe1ca52267304d76d1cf4801ce96
+#  RUN wget --no-verbose -O /liquibase/lib/mysql.jar https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.25/mysql-connector-java-8.0.25.jar \
+#  && wget --no-verbose -O /liquibase/lib/mysql.jar.asc https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.25/mysql-connector-java-8.0.25.jar.asc \
+#  && gpg --auto-key-locate keyserver --keyserver keyserver.ubuntu.com --keyserver-options auto-key-retrieve --verify /liquibase/lib/mysql.jar.asc /liquibase/lib/mysql.jar \
+#  && echo "$MYSQL_SHA256  /liquibase/lib/mysql.jar" | sha256sum -c -
+
+      - name: Install tools
+        run: npm run tools-setup
 
       - name: Build Artifact
         run: npm run build

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -37,8 +37,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install tools
-        run: npm run tools-setup
+#      - name: Install tools
+#        run: npm run tools-setup
 
       - name: Build Artifact
         run: npm run build

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -54,7 +54,8 @@ jobs:
           curl -L https://github.com/liquibase/liquibase/releases/download/v${LB_VERSION}/liquibase-${LB_VERSION}.zip --output liquibase-${LB_VERSION}.zip
           unzip -o -d liquibase liquibase-${LB_VERSION}.zip
           echo "$GITHUB_WORKSPACE/liquibase" >> $GITHUB_PATH
-          curl -L https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MJC_VERSION}/mysql-connector-java-${MJC_VERSION}.jar --create-dirs --output /liquibase/lib/mysql.jar
+          mkdir -p /liquibase/lib/
+          curl -L https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MJC_VERSION}/mysql-connector-java-${MJC_VERSION}.jar --output /liquibase/lib/mysql.jar
           
 ## Make /liquibase directory and change owner to liquibase
 #  RUN mkdir /liquibase

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -41,9 +41,8 @@ jobs:
         run: |
           sudo systemctl start mysql.service
           mysqladmin -u root -p'root' password 12345
-          cat /etc/hosts
+          # remove ipv6 localhost to allow test-i pack to run correctly
           sudo sed -i '/::1     localhost/d' /etc/hosts
-          cat /etc/hosts
 
       - name: Install Liquibase
         env:
@@ -62,14 +61,12 @@ jobs:
           repository: dvsa/cvs-nop
           path: cvs-nop
           ref: ${{ github.ref }}
-      - run: mv cvs-nop/ ..
+
+      - name: Move CVS-NOP
+        run: mv cvs-nop/ ..
 
       - name: Install tools
         run: npm run tools-setup
-#    "tools-setup": "liquibase --changeLogFile ../cvs-nop/changelog-master.xml --username root --password 12345 --url jdbc:mysql://127.0.0.1:3306/CVSBNOP?createDatabaseIfNotExist=true --classpath /liquibase/lib/mysql.jar update"
-
-      - name: Test DB access
-        run: mysql -u root -p'12345' -h localhost -P 3306 -D CVSBNOP
 
       - name: Build Artifact
         run: npm run build

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -41,7 +41,7 @@ jobs:
         env:
           DB_PASSWORD: 12345
         run: |
-          echo "mysql-server mysql-server/root_password_again password $DB_PASSWORD" | debconf-set-selections
+          sudo echo "mysql-server mysql-server/root_password_again password $DB_PASSWORD" | debconf-set-selections
           sudo systemctl start mysql.service
 
       - name: Install Liquibase

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: dvsa/cvs-nop
-          path: cvs-nop
+          path: ../cvs-nop
           ref: ${{ github.ref }}
 
       - name: List Dirs

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -24,6 +24,11 @@ jobs:
         with:
           path: main
 
+      - name: List Dirs
+        run: |
+          ls -al
+          ls -al ..
+
       - name: Get AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, X64]
     services:
       mysql:
         image: mysql:8.0
@@ -58,7 +58,7 @@ jobs:
 #      - name: Start MySQL
 #        if: ${{ inputs.mysql_liquibase == true }}
 #        run: |
-#          ls /usr/local/mysql
+#          sudo systemctl start mysql.service
 #          mysqladmin -u root -p'root' password 12345
 
       - name: Install Liquibase

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -27,16 +27,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: [self-hosted, X64]
-    services:
-      mysql:
-        image: mysql:8.0
-        env:
-          MYSQL_DATABASE: CVSBNOP
-          MYSQL_ROOT_PASSWORD: 12345
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -55,11 +46,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-#      - name: Start MySQL
-#        if: ${{ inputs.mysql_liquibase == true }}
-#        run: |
-#          sudo systemctl start mysql.service
-#          mysqladmin -u root -p'root' password 12345
+      - name: Start MySQL
+        if: ${{ inputs.mysql_liquibase == true }}
+        run: |
+          sudo systemctl start mysql.service
+          mysqladmin -u root -p'root' password 12345
+          # remove ipv6 localhost to allow test-i pack to run correctly
+          sudo sed -i '/::1     localhost/d' /etc/hosts
 
       - name: Install Liquibase
         if: ${{ inputs.mysql_liquibase == true }}

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -42,7 +42,7 @@ jobs:
           sudo systemctl start mysql.service
           mysqladmin -u root -p'root' password 12345
           cat /etc/hosts
-          sudo sed -i '/::1/d' /etc/hosts
+          sudo sed -i '/::1     localhost/d' /etc/hosts
           cat /etc/hosts
 
       - name: Install Liquibase

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -41,9 +41,8 @@ jobs:
         env:
           DB_PASSWORD: 12345
         run: |
-          printenv
+          echo "mysql-server mysql-server/root_password_again password $DB_PASSWORD" | debconf-set-selections
           sudo systemctl start mysql.service
-          mysqladmin -u root -p'root' password ${DB_PASSWORD}
 
       - name: Install Liquibase
         env:
@@ -61,7 +60,9 @@ jobs:
           echo "$GITHUB_WORKSPACE/liquibase" >> $GITHUB_PATH
           sudo mkdir -p /liquibase/lib/
           sudo curl -L https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MJC_VERSION}/mysql-connector-java-${MJC_VERSION}.jar --output /liquibase/lib/mysql.jar
-          
+
+#  echo "mysql-server mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD" | debconf-set-selections
+
 ## Make /liquibase directory and change owner to liquibase
 #  RUN mkdir /liquibase
 #  WORKDIR /liquibase

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -27,7 +27,16 @@ permissions:
 
 jobs:
   build:
-    runs-on: [self-hosted, X64]
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_DATABASE: CVSBNOP
+          MYSQL_ROOT_PASSWORD: 12345
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - uses: actions/checkout@v4
 
@@ -46,11 +55,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Start MySQL
-        if: ${{ inputs.mysql_liquibase == true }}
-        run: |
-          ls /usr/local/mysql
-          mysqladmin -u root -p'root' password 12345
+#      - name: Start MySQL
+#        if: ${{ inputs.mysql_liquibase == true }}
+#        run: |
+#          ls /usr/local/mysql
+#          mysqladmin -u root -p'root' password 12345
 
       - name: Install Liquibase
         if: ${{ inputs.mysql_liquibase == true }}

--- a/.github/workflows/build-node-hash.yaml
+++ b/.github/workflows/build-node-hash.yaml
@@ -6,6 +6,15 @@ on:
       mono_repo:
         type: boolean
         default: false
+      mysql_liquibase:
+        type: boolean
+        default: false
+      liquibase_version:
+        type: string
+        default: 4.23.0
+      mysql_connector_java_version:
+        type: string
+        default: 8.0.25
     secrets:
       CVS_MGMT_AWS_ROLE:
         required: true
@@ -38,6 +47,7 @@ jobs:
         run: npm ci
 
       - name: Start MySQL
+        if: ${{ inputs.mysql_liquibase == true }}
         run: |
           sudo systemctl start mysql.service
           mysqladmin -u root -p'root' password 12345
@@ -45,17 +55,16 @@ jobs:
           sudo sed -i '/::1     localhost/d' /etc/hosts
 
       - name: Install Liquibase
-        env:
-          LB_VERSION: 4.23.0
-          MCJ_VERSION: 8.0.25
+        if: ${{ inputs.mysql_liquibase == true }}
         run: |
-          curl -L https://github.com/liquibase/liquibase/releases/download/v${LB_VERSION}/liquibase-${LB_VERSION}.zip --output liquibase-${LB_VERSION}.zip
-          unzip -o -d liquibase liquibase-${LB_VERSION}.zip
+          curl -L https://github.com/liquibase/liquibase/releases/download/v${{ inputs.liquibase_version }}/liquibase-${{ inputs.liquibase_version }}.zip --output liquibase-${{ inputs.liquibase_version }}.zip
+          unzip -o -d liquibase liquibase-${{ inputs.liquibase_version }}.zip
           echo "$GITHUB_WORKSPACE/liquibase" >> $GITHUB_PATH
           sudo mkdir -p /liquibase/lib/
-          sudo curl -L https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MCJ_VERSION}/mysql-connector-java-${MCJ_VERSION}.jar --output /liquibase/lib/mysql.jar
+          sudo curl -L https://repo1.maven.org/maven2/mysql/mysql-connector-java/${{ inputs.mysql_connector_java_version }}/mysql-connector-java-${{ inputs.mysql_connector_java_version }}.jar --output /liquibase/lib/mysql.jar
 
       - name: Checkout CVS-NOP
+        if: ${{ inputs.mysql_liquibase == true }}
         uses: actions/checkout@v4
         with:
           repository: dvsa/cvs-nop
@@ -63,6 +72,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Move CVS-NOP
+        if: ${{ inputs.mysql_liquibase == true }}
         run: mv cvs-nop/ ..
 
       - name: Install tools


### PR DESCRIPTION
## Ticket title

Build Services from hash adding local mysql and liquibase compatibility.

Specifically https://github.com/dvsa/cvs-tsk-update-store has some npm run commands expecting a local mysql running and for local liquibase executable to be available. In Jenkins we had these included in the ci-builder container: https://github.com/dvsa/cvs-ci-builder/blob/main/Dockerfile and mysql running in a container: https://github.com/dvsa/cvs-builder-mysql/blob/master/Dockerfile

Example: solo-repo: 
https://github.com/dvsa/cvs-tsk-update-test-stations/actions/runs/7930261224/job/21652628744

Example: mono-repo: 
https://github.com/dvsa/cvs-svc-technical-records-v3/actions/runs/7933014993/job/21660803300

Example: solo-repo with mysql/liquibase: 
https://github.com/dvsa/cvs-tsk-update-store/actions/runs/7930441113/job/21659607428


[CB2-10412](https://dvsa.atlassian.net/browse/CB2-10412)

## Checklist
- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number