### PR TITLE
feat(CB2-19124): Don't put full checkov report in pr comment

### DIFF
--- a/terraform-pr-comment/action.yaml
+++ b/terraform-pr-comment/action.yaml
@@ -100,8 +100,10 @@ runs:
           #### Checkov Scan 📖\`${{ inputs.checkov-outcome }}\`
 
           <details><summary>Checkov scan output</summary>
-
+          
+          \`\`\`\n
           ${checkovOutput}
+          \`\`\`\n
           [🔗 View full Checkov report artifact](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
           </details>

--- a/terraform-pr-comment/action.yaml
+++ b/terraform-pr-comment/action.yaml
@@ -99,7 +99,12 @@ runs:
 
           #### Checkov Scan 📖\`${{ inputs.checkov-outcome }}\`
 
+          <details><summary>Checkov scan output</summary>
+
+          ${checkovOutput}
           [🔗 View full Checkov report artifact](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+          </details>
 
           *Pusher: @${{ github.actor }}, Workflow: \`${{ github.workflow }}\`*`;
 

--- a/terraform-pr-comment/action.yaml
+++ b/terraform-pr-comment/action.yaml
@@ -46,7 +46,8 @@ runs:
           }
           let checkovOutput = '';
           try {
-            checkovOutput = fs.readFileSync('checkov-report-${{ github.run_id }}.md/results_github_failed_only.md', 'utf8');
+            checkovFull = fs.readFileSync('checkov-report-${{ github.run_id }}.md/results_github_failed_only.md', 'utf8');
+            checkovOutput = checkovFull.split('\n').find(line => line.includes('Passed Checks:')).trim();
           } catch (e) {
             checkovOutput = 'Checkov report not found.';
           }
@@ -98,11 +99,7 @@ runs:
 
           #### Checkov Scan 📖\`${{ inputs.checkov-outcome }}\`
 
-          <details><summary>Checkov scan output</summary>
-
-          ${checkovOutput}
-
-          </details>
+          [🔗 View full Checkov report artifact](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
           *Pusher: @${{ github.actor }}, Workflow: \`${{ github.workflow }}\`*`;
 


### PR DESCRIPTION
## Ticket title
Consolidate labeller and CI github actions
https://dvsa.atlassian.net/browse/CB2-19124

The checkov scan can end up being huge, and will in some cases push the PR comment over the character limit. Can just comment the summary and a link to the full plan instead.

## Checklist
- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number