### PR TITLE
Remove Caching from Encryption Action

### DIFF
--- a/aws-encrypt/action.yaml
+++ b/aws-encrypt/action.yaml
@@ -21,16 +21,7 @@ runs:
       with:
         python-version: '3.12' 
 
-    - name: Cache PIP
-      uses: actions/cache@v4
-      id: cache
-      with:
-          path: ./encrypt
-          key: encrypt
-          # restore-keys: encrypt-
-
     - name: Install Encryption CLI
-      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
         # Install the AWS Encrpytion CLI


### PR DESCRIPTION
## Ticket title
The Encryption Cache fails depending on if a subfolder is used or not, rather than waste time on this just remove the caching (jobs will take slightly longer).

CB2-19646

## Checklist
- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number