### PR TITLE
feat(cb2-21774): add new create db schema action

### DIFF
--- a/create-db-schema/action.yaml
+++ b/create-db-schema/action.yaml
@@ -1,0 +1,88 @@
+name: Create DB Schema
+description: Run a workflow in another repository with access to the Database
+
+inputs:
+  environment:
+    description: Environment
+    type: string
+    required: true
+  schema:
+    description: Schema Name
+    required: true
+  database:
+    description: Database Connection
+    required: true
+  drop-schema:
+    description: Drop Schema (to recreate)
+    default: false
+  repository:
+    description: Repository Name
+    default: cvs-devops
+  branch:
+    description: Branch to run Workflow from
+    required: false
+  workflow:
+    description: Workflow File
+    default: create-db-schema.yaml
+  dry-run:
+    description: Dry Run
+    default: false
+
+outputs:
+  schema: 
+    description: Schema Name
+    value: ${{ steps.schema.outputs.schema }}
+  service-name: 
+    description: Service Name
+    value: ${{ steps.schema.outputs.service-name }}
+
+runs:
+  using: composite
+  steps:
+    - name: Upload Configuration
+      uses: actions/upload-artifact@v7
+      with:
+        path: db/**
+        name: db
+
+    - name: Trigger Schema Creation
+      id: schema
+      shell: bash
+      run: |
+        # Generate Package
+        package=$(jq -nc '{environment: "${{ inputs.environment }}", schema: "${{ inputs.schema }}", database: "${{ inputs.database }}", "drop-schema": "${{ inputs.drop-schema }}", "dry-run": "${{ inputs.dry-run }}", "repository": "${{ github.repository}}", "workflow-id": "${{ github.run_id }}"}')
+
+        repository=${{ case(startsWith(inputs.repository, 'dvsa'), inputs.repository, format('dvsa/{0}', inputs.repository)) }}
+
+        # Trigger workflow
+        url=$(gh workflow run ${{ inputs.workflow }}${{ case(inputs.branch != '', format(' --ref {0}', inputs.branch), '') }} -R ${repository} --json <<< "${package}" | grep "https")
+        run=$(basename ${url})
+        
+        echo "Running ${{ inputs.workflow }} in ${{ inputs.repository }}"
+        echo "${url}"
+
+        # Wait for completion
+        while [ -z $(gh run view ${run} --json conclusion --jq '.conclusion' -R ${repository}) ]; do
+          sleep 5
+        done 
+
+        # Output Results
+        result=$(gh run view ${run} --json conclusion,status,databaseId,displayTitle,startedAt,url -R ${repository})
+        echo "**$(jq -r '.displayTitle' <<< $result)**" >> $GITHUB_STEP_SUMMARY
+        echo "**Status:** $(jq -r '.conclusion' <<< $result)" >> $GITHUB_STEP_SUMMARY
+        echo "**Schema:** ${{ inputs.schema }}" >> $GITHUB_STEP_SUMMARY
+        echo "**Database:** ${{ inputs.database }}" >> $GITHUB_STEP_SUMMARY
+        echo "**Branch:** ${{ inputs.branch }}" >> $GITHUB_STEP_SUMMARY
+        echo "**Environment:** ${{ inputs.environment }}" >> $GITHUB_STEP_SUMMARY
+        echo "**Drop Existing Schema:** ${{ inputs.drop-schema }}" >> $GITHUB_STEP_SUMMARY
+        echo "**Run Time:** $(jq -r '.startedAt' <<< $result)" >> $GITHUB_STEP_SUMMARY
+        echo "**Run ID:** $(jq -r '.databaseId' <<< $result)" >> $GITHUB_STEP_SUMMARY
+        echo "**Dry Run:** ${{ inputs.dry-run }}" >> $GITHUB_STEP_SUMMARY
+        echo "**URL:** $(jq -r '.url' <<< $result)" >> $GITHUB_STEP_SUMMARY
+
+        # Fail on error
+        success=( success skipped )
+        if ! [[ ${success} =~ "$(jq -r '.conclusion' <<< $result)" ]]; then
+          echo "Create Schema Failed"
+          exit 1
+        fi

--- a/create-db-schema/readme.md
+++ b/create-db-schema/readme.md
@@ -1,0 +1,56 @@
+# Create DB Schema
+
+Triggers a workflow in another repository to create a database schema with access to the target database. The action uploads the local database configuration, invokes the specified workflow, waits for completion, and reports the results in the workflow summary.
+
+## Inputs
+
+This action requires the following inputs:
+
+* environment: Target environment where the schema should be created.
+* schema: Name of the schema to create.
+* database: Database connection identifier.
+* drop-schema: (optional) Drop the existing schema before recreating it - defaults to `false`.
+* repository: (optional) Repository containing the workflow to execute - defaults to `cvs-devops`.
+* branch: (optional) Branch to run the workflow from.
+* workflow: (optional) Workflow file to execute - defaults to `create-db-schema.yaml`.
+* dry-run: (optional) Perform a dry run without making changes - defaults to `false`.
+
+## Outputs
+
+This action produces the following outputs:
+
+* schema: The schema name that was processed.
+
+## Notes
+
+* This action requires GitHub CLI (`gh`) to be available on the runner.
+* The target workflow must support workflow dispatch and accept the expected input payload.
+* Any database configuration files located in the `db/` directory are uploaded as an artifact and made available to the triggered workflow.
+* The action waits for the triggered workflow to complete before continuing.
+* The action will fail if the triggered workflow does not complete successfully.
+
+## Usage Example
+
+```yaml
+...
+jobs:
+  create-schema:
+    runs-on: [runner]
+
+    steps:
+      - name: Create Database Schema
+        id: schema
+        uses: dvsa/cvs-github-actions/create-db-schema@develop
+        with:
+          environment: test
+          schema: my_schema
+          database: postgres-main
+          drop-schema: 'true'
+          repository: cvs-devops
+          workflow: create-db-schema.yaml
+          dry-run: 'false'
+
+      - name: Display Outputs
+        run: |
+          echo "Schema: ${{ steps.schema.outputs.schema }}"
+```


### PR DESCRIPTION
## Description

Adds a new action that is intended to trigger by the `create-db-schema` workflow located in `cvs-devops` to allow a standard repository to have a dependency on a DB table/Schema to be created as part of its deployment without having to have a `github-actions` runner registered in its repo.

Related issue: CB2-21774

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
