### PR TITLE
Change location of MySQL connector jar

### DIFF
--- a/liquibase-install/action.yaml
+++ b/liquibase-install/action.yaml
@@ -24,7 +24,7 @@ runs:
       shell: bash
       run: |
         echo "$GITHUB_WORKSPACE/liquibase" >> $GITHUB_PATH
-        sudo mkdir -p $GITHUB_WORKSPACE/liquibase/lib
-        sudo curl -L https://downloads.mysql.com/archives/get/p/3/file/mysql-connector-j-${{ inputs.mysql_connector_java_version }}.tar.gz --output mysql-connector-j.tar.gz
-        sudo tar -zxf mysql-connector-j.tar.gz
-        sudo mv -v mysql-connector-j-${{ inputs.mysql_connector_java_version }}/mysql-connector-j-${{ inputs.mysql_connector_java_version }}.jar $GITHUB_WORKSPACE/liquibase/lib/
+        mkdir -p $GITHUB_WORKSPACE/liquibase/lib
+        curl -L https://downloads.mysql.com/archives/get/p/3/file/mysql-connector-j-${{ inputs.mysql_connector_java_version }}.tar.gz --output mysql-connector-j.tar.gz
+        tar -zxf mysql-connector-j.tar.gz
+        mv -v mysql-connector-j-${{ inputs.mysql_connector_java_version }}/mysql-connector-j-${{ inputs.mysql_connector_java_version }}.jar $GITHUB_WORKSPACE/liquibase/lib/

--- a/liquibase-install/action.yaml
+++ b/liquibase-install/action.yaml
@@ -23,4 +23,4 @@ runs:
         sudo mkdir -p $GITHUB_WORKSPACE/liquibase/lib
         sudo curl -L https://downloads.mysql.com/archives/get/p/3/file/mysql-connector-j-${{ inputs.mysql_connector_java_version }}.tar.gz --output mysql-connector-j.tar.gz
         sudo tar -zxf mysql-connector-j.tar.gz
-        sudo mv mysql-connector-j-${{ inputs.mysql_connector_java_version }}/mysql-connector-j-${{ inputs.mysql_connector_java_version }}.jar $GITHUB_WORKSPACEliquibase/lib/
+        sudo mv mysql-connector-j-${{ inputs.mysql_connector_java_version }}/mysql-connector-j-${{ inputs.mysql_connector_java_version }}.jar $GITHUB_WORKSPACE/liquibase/lib/

--- a/liquibase-install/action.yaml
+++ b/liquibase-install/action.yaml
@@ -20,6 +20,7 @@ runs:
         curl -L https://github.com/liquibase/liquibase/releases/download/v${{ inputs.liquibase_version }}/liquibase-${{ inputs.liquibase_version }}.zip --output liquibase-${{ inputs.liquibase_version }}.zip
         unzip -o -d liquibase liquibase-${{ inputs.liquibase_version }}.zip
         echo "$GITHUB_WORKSPACE/liquibase" >> $GITHUB_PATH
-        sudo mkdir -p /liquibase/lib
+        sudo mkdir -p $GITHUB_WORKSPACE/liquibase/lib
         sudo curl -L https://downloads.mysql.com/archives/get/p/3/file/mysql-connector-j-${{ inputs.mysql_connector_java_version }}.tar.gz --output mysql-connector-j.tar.gz
-        sudo tar -zxf mysql-connector-j.tar.gz -C /liquibase/lib
+        sudo tar -zxf mysql-connector-j.tar.gz
+        sudo mv mysql-connector-j-${{ inputs.mysql_connector_java_version }}/mysql-connector-j-${{ inputs.mysql_connector_java_version }}.jar $GITHUB_WORKSPACEliquibase/lib/

--- a/liquibase-install/action.yaml
+++ b/liquibase-install/action.yaml
@@ -18,11 +18,12 @@ runs:
       run: |
         # Install Liquibase
         curl -L https://github.com/liquibase/liquibase/releases/download/v${{ inputs.liquibase_version }}/liquibase-${{ inputs.liquibase_version }}.zip --output liquibase-${{ inputs.liquibase_version }}.zip
-        unzip -o -d liquibase liquibase-${{ inputs.liquibase_version }}.zip
+        unzip -oq -d liquibase liquibase-${{ inputs.liquibase_version }}.zip
     
     - name: Download MySQL connector
       shell: bash
       run: |
+        echo "$GITHUB_WORKSPACE/liquibase" >> $GITHUB_PATH
         sudo mkdir -p $GITHUB_WORKSPACE/liquibase/lib
         sudo curl -L https://downloads.mysql.com/archives/get/p/3/file/mysql-connector-j-${{ inputs.mysql_connector_java_version }}.tar.gz --output mysql-connector-j.tar.gz
         sudo tar -zxf mysql-connector-j.tar.gz

--- a/liquibase-install/action.yaml
+++ b/liquibase-install/action.yaml
@@ -19,8 +19,11 @@ runs:
         # Install Liquibase
         curl -L https://github.com/liquibase/liquibase/releases/download/v${{ inputs.liquibase_version }}/liquibase-${{ inputs.liquibase_version }}.zip --output liquibase-${{ inputs.liquibase_version }}.zip
         unzip -o -d liquibase liquibase-${{ inputs.liquibase_version }}.zip
-        echo "$GITHUB_WORKSPACE/liquibase" >> $GITHUB_PATH
+    
+    - name: Download MySQL connector
+      shell: bash
+      run: |
         sudo mkdir -p $GITHUB_WORKSPACE/liquibase/lib
         sudo curl -L https://downloads.mysql.com/archives/get/p/3/file/mysql-connector-j-${{ inputs.mysql_connector_java_version }}.tar.gz --output mysql-connector-j.tar.gz
         sudo tar -zxf mysql-connector-j.tar.gz
-        sudo mv mysql-connector-j-${{ inputs.mysql_connector_java_version }}/mysql-connector-j-${{ inputs.mysql_connector_java_version }}.jar $GITHUB_WORKSPACE/liquibase/lib/
+        sudo mv -v mysql-connector-j-${{ inputs.mysql_connector_java_version }}/mysql-connector-j-${{ inputs.mysql_connector_java_version }}.jar $GITHUB_WORKSPACE/liquibase/lib/


### PR DESCRIPTION
## Stop using root /liquibase and use cwd instead
Downloaded connector tar.gz now unpacked inplace, then jar moved into liquibase/lib so that workflows accessing the liquibase-install composite do not need a classpath attribute in the liquibase.properties file. 

Removed unnecessary sudos

## Checklist
- [x] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number