### PR TITLE
feat: copy connector with another name as well as moving

### DIFF
--- a/liquibase-install/action.yaml
+++ b/liquibase-install/action.yaml
@@ -27,4 +27,5 @@ runs:
         mkdir -p $GITHUB_WORKSPACE/liquibase/lib
         curl -L https://downloads.mysql.com/archives/get/p/3/file/mysql-connector-j-${{ inputs.mysql_connector_java_version }}.tar.gz --output mysql-connector-j.tar.gz
         tar -zxf mysql-connector-j.tar.gz
+        cp mysql-connector-j-${{ inputs.mysql_connector_java_version }}/mysql-connector-j-${{ inputs.mysql_connector_java_version }}.jar $GITHUB_WORKSPACE/liquibase/lib/mysql.jar
         mv -v mysql-connector-j-${{ inputs.mysql_connector_java_version }}/mysql-connector-j-${{ inputs.mysql_connector_java_version }}.jar $GITHUB_WORKSPACE/liquibase/lib/


### PR DESCRIPTION
## Ticket title
Aliases downloaded mysql connector to mysql.jar in liquibase/lib to support mysql-create-schema/action.yaml which downloads liquibase.properties from secrets manager...

## Checklist
- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number